### PR TITLE
Fix Firebase profile image reload by persisting Storage path instead of signed URL

### DIFF
--- a/login/fire-profile9.html
+++ b/login/fire-profile9.html
@@ -229,6 +229,11 @@ onTokenChanged(appCheck, (token) => {
   const uploadInput = document.getElementById("upload-image");
   const changePicBtn = document.getElementById("change-pic-btn");
 
+  const withCacheBust = (url) => {
+    const separator = url.includes("?") ? "&" : "?";
+    return `${url}${separator}t=${Date.now()}`;
+  };
+
   /* Open file picker only on button click */
   changePicBtn.onclick = () => uploadInput.click();
 
@@ -246,7 +251,21 @@ onTokenChanged(appCheck, (token) => {
       const data = snap.val();
       nameEl.textContent = data.displayName || "No Name";
       if (data.profilePic) {
-        profilePicEl.src = data.profilePic + "&t=" + Date.now();
+        try {
+          const imagePath = data.profilePic;
+
+          // Backward compatibility: if older records still store full URLs,
+          // keep displaying them until the user uploads a new image.
+          if (imagePath.startsWith("http")) {
+            profilePicEl.src = withCacheBust(imagePath);
+          } else {
+            const freshDownloadURL = await getDownloadURL(sRef(storage, imagePath));
+            profilePicEl.src = withCacheBust(freshDownloadURL);
+          }
+        } catch (err) {
+          console.error("Failed to load profile picture:", err);
+          profilePicEl.src = "default-avatar.png";
+        }
       }
     }
   });
@@ -273,15 +292,16 @@ onTokenChanged(appCheck, (token) => {
 
       await uploadBytes(imageRef, file);
       const downloadURL = await getDownloadURL(imageRef);
+      const imagePath = imageRef.fullPath;
 
-      /* 3️⃣ Save final URL to RTDB */
+      /* 3️⃣ Save storage path to RTDB */
       await set(
         ref(db, `users/${user.uid}/profilePic`),
-        downloadURL
+        imagePath
       );
 
       /* 4️⃣ Replace local preview with server image */
-      profilePicEl.src = downloadURL + "&t=" + Date.now();
+      profilePicEl.src = withCacheBust(downloadURL);
       URL.revokeObjectURL(localURL);
 
     } catch (err) {


### PR DESCRIPTION
### Motivation
- Storing Firebase Storage signed download URLs in the database caused `SignatureDoesNotMatch` after logout/login because those signed URLs expire when auth/App Check tokens change.
- The change aims to persist a stable Storage object path and generate a fresh signed URL per session to avoid stale URL reuse.

### Description
- On upload the code now saves the Storage object path (`imageRef.fullPath`) to `users/{uid}/profilePic` instead of the signed download URL in `login/fire-profile9.html`.
- On auth load the code treats the DB value as a path and calls `getDownloadURL(sRef(storage, imagePath))` to obtain a fresh signed URL before setting the image source.
- Added a `withCacheBust` helper which appends `?t=` or `&t=` safely to avoid caching, and used it when setting `profilePicEl.src`.
- Added backward compatibility to display legacy full `http` URLs if present and an error fallback to `default-avatar.png` when URL resolution fails.

### Testing
- Located and inspected relevant files with `rg` and `sed` to confirm affected usages and lines, and these searches completed successfully.
- Verified the patch was applied and reviewed with `git -C /workspace/coolsite diff -- login/fire-profile9.html` which showed the intended changes and completed successfully.
- Committed the change with `git -C /workspace/coolsite commit -m "Fix profile image persistence by storing storage path"` which succeeded.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698817355bbc8325b017a80db6c06ac6)